### PR TITLE
Make SSH access to VM not trip over old host key fingerprints

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -135,7 +135,6 @@
   "terminal.integrated.fontFamily": "FiraMono Nerd Font Mono",
   "terminal.integrated.commandsToSkipShell": [],
   "terminal.integrated.scrollbar.alwaysConsumeMouseWheel": true,
-  "terminal.integrated.shell.linux": "/usr/bin/fish",
   "vs-kubernetes.vs-kubernetes.namespace": "*",
   "vs-kubernetes.vs-kubernetes.outputFormat": "yaml",
   "vs-kubernetes.vs-kubernetes.helm-path": "/usr/local/bin/helm",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -219,5 +219,6 @@
   "zoma.vscode-auto-open-workspace": {
     "enableAutoOpenIfSingleWorkspace": false,
     "enableAutoOpenAlwaysFirst": false
-  }
+  },
+  "runme.terminal.rows": 20
 }

--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ Deploy an Ubuntu Virtual Machine on the platform using Kubevirt.
 > **Note:** Run this step manually via integrated terminal.
 
 ```bash {"excludeFromRunAll":"true","id":"01J5VC1KTJBR22WEDNT2EWEW9Q","name":"vm"}
+# Purge old known host fingerprints
+task ssh-clean
+
 # Enable the VM instance
 pulumi config set --path vm.enabled true
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ ssh -p 30590 -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no kc2@localhost screenfe
 
 Use `virtctl` to access the VM via SSH without a NodePort service.
 
-```bash {"excludeFromRunAll":"true","id":"01J5VC1KTJBR22WEDNT6VNC5EK","name":"virtctl-ssh"}
+```bash {"background":"true","excludeFromRunAll":"true","id":"01J5VC1KTJBR22WEDNT6VNC5EK","name":"virtctl-ssh"}
 # SSH using virtctl
 virtctl ssh kc2@ubuntu
 ```
@@ -126,7 +126,7 @@ virtctl ssh kc2@ubuntu
 
 Use `virtctl` to access the serial console of the VM.
 
-```bash {"excludeFromRunAll":"true","id":"01J5VC1KTJBR22WEDNT7BDRMAV","name":"virtctl-console"}
+```bash {"background":"true","excludeFromRunAll":"true","id":"01J5VC1KTJBR22WEDNT7BDRMAV","name":"virtctl-console"}
 # Serial console access
 virtctl console ubuntu
 ```

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -86,13 +86,20 @@ tasks:
       - task: iac-cancel
       - task: iac-clean
 
+  ssh-clean:
+    desc: "Clean up all local SSH known hosts."
+    cmds:
+      - ssh-keygen -f "/home/vscode/.ssh/known_hosts" -R "[127.0.0.1]:30590" 2>/dev/null || true
+      - ssh-keygen -f "/home/vscode/.ssh/known_hosts" -R "[localhost]:30590" 2>/dev/null || true
+      - ssh-keygen -f "/home/vscode/.ssh/kubevirt_known_hosts" -R "vmi/ubuntu.default" 2>/dev/null || true
+
   clean-all:
     desc: "Clean up all local Kargo resources."
     deps:
       - kubernetes-clean
+      - ssh-clean
       - clean
     cmds:
-      - ssh-keygen -f "/home/vscode/.ssh/known_hosts" -R "[127.0.0.1]:30590" 2>/dev/null || true
       - rm -rf .talos/manifest/* .kube/config .ssh/known_hosts 2>/dev/null || true
       - rm ${HOME}/.pulumi ${HOME}/.kube ${HOME}/.talos 2>/dev/null || true
 


### PR DESCRIPTION
Here's the problem which occurs after creating a VM, tearing it down, and recreating it: https://gist.github.com/sourishkrout/801942d31094ae64e642a29fc2ba963a#file-01j6jq0cz5dteqp3fz827a4p8f-md

- Removes old keys from all relevant `known_hosts` files.

It also improves the Runme experience by
- Delegating long-running cells to "background"
- Default notebook terminals to 20 rows instead of the default 10